### PR TITLE
Use LD_LIBRARY_PATH on linux

### DIFF
--- a/turbojpeg.py
+++ b/turbojpeg.py
@@ -253,6 +253,12 @@ class TurboJPEG(object):
         for lib_path in DEFAULT_LIB_PATHS[platform.system()]:
             if os.path.exists(lib_path):
                 return lib_path
+        if platform.system() == 'Linux' and 'LD_LIBRARY_PATH' in os.environ:
+            ld_library_path = os.environ['LD_LIBRARY_PATH']
+            for path in ld_library_path.split(':'):
+                lib_path = os.path.join(path, 'libturbojpeg.so.0')
+                if os.path.exists(lib_path):
+                    return lib_path
         raise RuntimeError(
             'Unable to locate turbojpeg library automatically. '
             'You may specify the turbojpeg library path manually.\n'


### PR DESCRIPTION
On some systems LD_LIBRARY_PATH is set to help find libraries. When
present this can help find the required library without requiring the
user to explicitly set it. This is specifically interesting for cases
like ubuntu snaps where libraries are installed to non-standard paths and
LD_LIBRARY_PATH is set to find them.