### PR TITLE
Expose TurboJPEG.__scaling_factors as property

### DIFF
--- a/turbojpeg.py
+++ b/turbojpeg.py
@@ -205,7 +205,6 @@ class TurboJPEG(object):
         if self.__get_error_code is not None:
             self.__get_error_code.argtypes = [c_void_p]
             self.__get_error_code.restype = c_int
-        self.__scaling_factors = []
         class ScalingFactor(Structure):
             _fields_ = ('num', c_int), ('denom', c_int)
         get_scaling_factors = turbo_jpeg.tjGetScalingFactors
@@ -213,9 +212,10 @@ class TurboJPEG(object):
         get_scaling_factors.restype = POINTER(ScalingFactor)
         num_scaling_factors = c_int()
         scaling_factors = get_scaling_factors(byref(num_scaling_factors))
-        for i in range(num_scaling_factors.value):
-            self.__scaling_factors.append(
-                (scaling_factors[i].num, scaling_factors[i].denom))
+        self.__scaling_factors = frozenset(
+            (scaling_factors[i].num, scaling_factors[i].denom)
+            for i in range(num_scaling_factors.value)
+        )
 
     def decode_header(self, jpeg_buf):
         """decodes JPEG header and returns image properties as a tuple.

--- a/turbojpeg.py
+++ b/turbojpeg.py
@@ -429,6 +429,10 @@ class TurboJPEG(object):
         """returns the memory address for a given ndarray"""
         return cast(nda.__array_interface__['data'][0], POINTER(c_ubyte))
 
+    @property
+    def scaling_factors (self):
+        return self.__scaling_factors
+
 if __name__ == '__main__':
     jpeg = TurboJPEG()
     in_file = open('input.jpg', 'rb')


### PR DESCRIPTION
I had to create an application that received a custom scaling factor and tries to do the best effort when scaling.
To solve this, I had to expose the supported scaling factors as a property, to search for the closest one.
This is a pull request to make this property available for everyone.