### PR TITLE
Modify encode function to support 1-channel input

### DIFF
--- a/turbojpeg.py
+++ b/turbojpeg.py
@@ -335,7 +335,7 @@ class TurboJPEG(object):
         try:
             jpeg_buf = c_void_p()
             jpeg_size = c_ulong()
-            height, width, _ = img_array.shape
+            height, width = img_array.shape[:2]
             src_addr = self.__getaddr(img_array)
             status = self.__compress(
                 handle, src_addr, width, img_array.strides[0], height, pixel_format,


### PR DESCRIPTION
Original encode function accept only three channels input image. This pull request reduce img_array shape output to only require parameters (height & width) make grayscale image can be used as input.