### PR TITLE
Add FreeBSD search path to avoid KeyError.

### DIFF
--- a/turbojpeg.py
+++ b/turbojpeg.py
@@ -41,6 +41,10 @@ DEFAULT_LIB_PATHS = {
         '/usr/lib64/libturbojpeg.so.0',
         '/opt/libjpeg-turbo/lib64/libturbojpeg.so'
     ],
+    'FreeBSD': [
+        '/usr/local/lib/libjpeg.so.8',
+        '/usr/local/lib/libjpeg.so'
+    ],
     'Windows': ['C:/libjpeg-turbo64/bin/turbojpeg.dll']
 }
 


### PR DESCRIPTION
I noticed this problem with Home Assistant, which I run on FreeBSD. When trying to find turbojpeg library, DEFAULT_LIB_PATHS is indexed by operating system name, resulting in KeyError.