### PR TITLE
Use libturbojpeg.so instead of libjpeg.so in FreeBSD.

### DIFF
--- a/turbojpeg.py
+++ b/turbojpeg.py
@@ -43,8 +43,8 @@ DEFAULT_LIB_PATHS = {
         '/opt/libjpeg-turbo/lib64/libturbojpeg.so'
     ],
     'FreeBSD': [
-        '/usr/local/lib/libjpeg.so.8',
-        '/usr/local/lib/libjpeg.so'
+        '/usr/local/lib/libturbojpeg.so.0',
+        '/usr/local/lib/libturbojpeg.so'
     ],
     'Windows': ['C:/libjpeg-turbo64/bin/turbojpeg.dll']
 }


### PR DESCRIPTION
FreeBSD has two packages for turbojpeg. graphics/jpeg doesn't
provide shared library with turbojpeg api, one needs to
use graphics/libjpeg-turbo for it.