### PR TITLE
fix incorrect logic on scale_with_quality() 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import io
 from setuptools import setup, find_packages
 setup(
     name='PyTurboJPEG',
-    version='1.6.2',
+    version='1.6.3',
     description='A Python wrapper of libjpeg-turbo for decoding and encoding JPEG image.',
     author='Lilo Huang',
     author_email='kuso.cc@gmail.com',

--- a/turbojpeg.py
+++ b/turbojpeg.py
@@ -23,7 +23,7 @@
 # SOFTWARE.
 
 __author__ = 'Lilo Huang <kuso.cc@gmail.com>'
-__version__ = '1.6.2'
+__version__ = '1.6.3'
 
 from ctypes import *
 from ctypes.util import find_library
@@ -502,7 +502,6 @@ class TurboJPEG(object):
                 handle, src_addr, jpeg_array.size, dest_addr, scaled_width, 4, scaled_height, flags)
             if status != 0:
                 self.__report_error(handle)
-                return
             self.__destroy(handle)
             handle = self.__init_compress()
             jpeg_buf = c_void_p()


### PR DESCRIPTION
scale_with_quality() returns empty data if decoding the image to be scaled triggers a warning. #53
