### PR TITLE
Improved encode() error handling on wrong array shape

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import io
 from setuptools import setup, find_packages
 setup(
     name='PyTurboJPEG',
-    version='1.6.4',
+    version='1.6.5',
     description='A Python wrapper of libjpeg-turbo for decoding and encoding JPEG image.',
     author='Lilo Huang',
     author_email='kuso.cc@gmail.com',

--- a/turbojpeg.py
+++ b/turbojpeg.py
@@ -36,7 +36,10 @@ from struct import unpack, calcsize
 
 # default libTurboJPEG library path
 DEFAULT_LIB_PATHS = {
-    'Darwin': ['/usr/local/opt/jpeg-turbo/lib/libturbojpeg.dylib'],
+    'Darwin': [
+        '/usr/local/opt/jpeg-turbo/lib/libturbojpeg.dylib',
+        '/opt/libjpeg-turbo/lib64/libturbojpeg.dylib'
+    ],
     'Linux': [
         '/usr/lib/x86_64-linux-gnu/libturbojpeg.so.0',
         '/usr/lib64/libturbojpeg.so.0',

--- a/turbojpeg.py
+++ b/turbojpeg.py
@@ -23,7 +23,7 @@
 # SOFTWARE.
 
 __author__ = 'Lilo Huang <kuso.cc@gmail.com>'
-__version__ = '1.6.4'
+__version__ = '1.6.5'
 
 from ctypes import *
 from ctypes.util import find_library

--- a/turbojpeg.py
+++ b/turbojpeg.py
@@ -114,6 +114,10 @@ TJXOPT_NOOUTPUT = 16
 TJXOPT_PROGRESSIVE = 32
 TJXOPT_COPYNONE = 64
 
+# pixel size
+# see details in https://github.com/libjpeg-turbo/libjpeg-turbo/blob/master/turbojpeg.h
+tjPixelSize = [3, 3, 4, 4, 4, 4, 1, 4, 4, 4, 4, 4]
+
 # MCU block width (in pixels) for a given level of chrominance subsampling.
 # MCU block sizes:
 #  - 8x8 for no subsampling or grayscale
@@ -142,10 +146,6 @@ TJFLAG_ACCURATEDCT = 4096
 TJFLAG_STOPONWARNING = 8192
 TJFLAG_PROGRESSIVE = 16384
 TJFLAG_LIMITSCANS = 32768
-
-# pixel size
-# see details in https://github.com/libjpeg-turbo/libjpeg-turbo/blob/master/turbojpeg.h
-tjPixelSize = [3, 3, 4, 4, 4, 4, 1, 4, 4, 4, 4, 4]
 
 class CroppingRegion(Structure):
     _fields_ = [("x", c_int), ("y", c_int), ("w", c_int), ("h", c_int)]


### PR DESCRIPTION
1. Improved encode() error handling on wrong array shape (#57) 
2. Added an extra turbojpeg default path for Mac OS