### PR TITLE
Optimize Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,22 +145,22 @@ cv2.waitKey(0)
 
 ### macOS
 - brew install jpeg-turbo
-- pip install -U git+git://github.com/lilohuang/PyTurboJPEG.git
+- pip install -U git+https://github.com/lilohuang/PyTurboJPEG.git
 
 ### Windows 
 - Download [libjpeg-turbo official installer](https://sourceforge.net/projects/libjpeg-turbo/files) 
-- pip install -U git+git://github.com/lilohuang/PyTurboJPEG.git
+- pip install -U git+https://github.com/lilohuang/PyTurboJPEG.git
 
 ### Linux
 - RHEL/CentOS/Fedora
   - Download [libjpeg-turbo.repo](https://libjpeg-turbo.org/pmwiki/uploads/Downloads/libjpeg-turbo.repo) to /etc/yum.repos.d/
   - sudo yum install libjpeg-turbo-official
-  - pip install -U git+git://github.com/lilohuang/PyTurboJPEG.git
+  - pip install -U git+https://github.com/lilohuang/PyTurboJPEG.git
 
 - Ubuntu
   - sudo apt-get update
   - sudo apt-get install libturbojpeg
-  - pip install -U git+git://github.com/lilohuang/PyTurboJPEG.git
+  - pip install -U git+https://github.com/lilohuang/PyTurboJPEG.git
 
 ## Benchmark 
 


### PR DESCRIPTION
Reason:

- Following [pip official document](https://pip.pypa.io/en/stable/topics/vcs-support/), `git+git` is not recommended.
- Current command will make pip call `git clone git://github.com/lilohuang/PyTurboJPEG.git`, which will result in a timeout error on some systems (i.e. ubuntu 22.04 + git 2.25.1).  The correct command should be `git clone git@github.com:lilohuang/PyTurboJPEG.git`.