### PR TITLE
Add alpine linux libturbojpeg lib path

### DIFF
--- a/turbojpeg.py
+++ b/turbojpeg.py
@@ -43,6 +43,7 @@ DEFAULT_LIB_PATHS = {
     ],
     'Linux': [
         '/usr/lib/x86_64-linux-gnu/libturbojpeg.so.0',
+        '/usr/lib/libturbojpeg.so.0'
         '/usr/lib64/libturbojpeg.so.0',
         '/opt/libjpeg-turbo/lib64/libturbojpeg.so'
     ],


### PR DESCRIPTION
The alpine [`libturbojpeg`](https://pkgs.alpinelinux.org/package/edge/main/x86_64/libturbojpeg) package places the lib under [`/usr/lib/libturbojpeg.so.0`](https://git.alpinelinux.org/aports/tree/main/libjpeg-turbo/APKBUILD#n92), which is not currently covered by `__find_turbojpeg()`.

Adding this location to `DEFAULT_LIB_PATHS` so it can be found by default
