### PR TITLE
Fix encode API compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,33 @@ in_file.close()
 out_file = open('lossless_cropped_output.jpg', 'wb')
 out_file.write(jpeg.crop(open('input.jpg', 'rb').read(), 8, 8, 320, 240))
 out_file.close()
+
+# in-place decoding input.jpg to BGR array
+# here I use a 640x480 example (in practise, read the dimensions)
+in_file = open('input.jpg', 'rb')
+img_array = np.empty((640, 480, 3), dtype=np.uint8)
+result = jpeg.decode(in_file.read(), dst=img_array)
+in_file.close()
+
+# return value is the img_array argument value
+id(result) == id(img_array)
+# True
+
+# Optional: display the in-place array
+# cv2.imshow('img_array', img_array)
+# cv2.waitKey(0)
+
+# in-place encoding with default settings.
+buffer_size = jpeg.buffer_size(img_array)
+dest_buf = bytearray(buffer_size)
+result, n_byte = jpeg.encode(img_array, dst=dest_buf)
+
+# return value is the dest_buf argument value
+id(result) == id(dest_buf)
+
+out_file = open('output.jpg', 'wb')
+out_file.write(dest_buf[:n_byte])
+out_file.close()
 ```
 
 ```python

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import io
 from setuptools import setup, find_packages
 setup(
     name='PyTurboJPEG',
-    version='1.8.1',
+    version='1.8.2',
     description='A Python wrapper of libjpeg-turbo for decoding and encoding JPEG image.',
     author='Lilo Huang',
     author_email='kuso.cc@gmail.com',

--- a/turbojpeg.py
+++ b/turbojpeg.py
@@ -23,7 +23,7 @@
 # SOFTWARE.
 
 __author__ = 'Lilo Huang <kuso.cc@gmail.com>'
-__version__ = '1.8.1'
+__version__ = '1.8.2'
 
 from ctypes import *
 from ctypes.util import find_library
@@ -522,7 +522,7 @@ class TurboJPEG(object):
                 self.__free(jpeg_buf)
             else:
                 result = dst
-            return result if dst is None else result, jpeg_size.value
+            return result if dst is None else (result, jpeg_size.value)
         finally:
             self.__destroy(handle)
 


### PR DESCRIPTION
When dst is None, the return value of encode should be a bytearray to maintain compatibility with existing applications.