### PR TITLE
Add method for lossless optimization of Huffman tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,13 @@ with open('input.jpg', 'rb') as f:
     cropped_data = jpeg.crop(f.read(), 8, 8, 320, 240)
 with open('cropped_output.jpg', 'wb') as f:
     f.write(cropped_data)
+
+# Lossless Huffman table optimization (re-encodes with optimal tables,
+# identical pixels; typically smaller unless already optimized)
+with open('input.jpg', 'rb') as f:
+    optimized_data = jpeg.optimize(f.read())
+with open('optimized_output.jpg', 'wb') as f:
+    f.write(optimized_data)
 ```
 
 ### In-Place Operations

--- a/TESTING.md
+++ b/TESTING.md
@@ -26,6 +26,7 @@ The test suite covers all core functions of PyTurboJPEG plus regression tests fo
 - **scale_with_quality()** - Tests scaling and quality adjustment
 - **crop()** - Tests lossless crop operations
 - **crop_multiple()** - Tests multiple crop operations with background handling
+- **optimize()** - Tests lossless Huffman table optimization
 - **buffer_size()** - Tests buffer size calculation
 - **scaling_factors** - Tests the scaling factors property
 
@@ -109,6 +110,7 @@ Each test class focuses on a specific function or feature:
 - `TestScaleWithQuality` - Tests scaling with quality adjustment
 - `TestCrop` - Tests lossless crop operations
 - `TestCropMultiple` - Tests multiple crop operations
+- `TestOptimize` - Tests lossless Huffman table optimization
 - `TestBufferSize` - Tests buffer size calculation
 - `TestErrorHandling` - Tests error conditions
 - `TestIntegration` - Tests complete workflows

--- a/tests/test_turbojpeg.py
+++ b/tests/test_turbojpeg.py
@@ -513,6 +513,17 @@ class TestCropMultiple:
         assert subsample == TJSAMP_GRAY
 
 
+class TestOptimize:
+    """Test optimize function."""
+
+    def test_optimize_is_lossless(self, jpeg_instance, encoded_sample_jpeg):
+        """Test optimization returns a valid JPEG with unchanged pixels."""
+        optimized = jpeg_instance.optimize(encoded_sample_jpeg)
+        original_pixels = jpeg_instance.decode(encoded_sample_jpeg)
+        optimized_pixels = jpeg_instance.decode(optimized)
+        assert np.array_equal(original_pixels, optimized_pixels)
+
+
 class TestBufferSize:
     """Test buffer_size function."""
     

--- a/turbojpeg.py
+++ b/turbojpeg.py
@@ -125,6 +125,7 @@ TJXOPT_GRAY = 8
 TJXOPT_NOOUTPUT = 16
 TJXOPT_PROGRESSIVE = 32
 TJXOPT_COPYNONE = 64
+TJXOPT_OPTIMIZE = 256  # Huffman table optimization
 
 # pixel size
 # see details in https://github.com/libjpeg-turbo/libjpeg-turbo/blob/main/src/turbojpeg.h
@@ -1347,6 +1348,43 @@ class TurboJPEG(object):
             results = self.__do_transform(handle, src_addr, jpeg_array.size, number_of_operations, crop_transforms)
 
             return results
+
+        finally:
+            self.__destroy(handle)
+
+    def optimize(self, jpeg_buf, copynone=False):
+        """Losslessly optimize the Huffman tables of a jpeg image.
+
+        Re-encodes the entropy-coded data with optimal Huffman tables
+        (equivalent to ``jpegtran -optimize``) without any loss in image
+        quality. Typically reduces file size, unless the input is already
+        optimized.
+
+        Parameters
+        ----------
+        jpeg_buf: bytes
+            Input jpeg image.
+        copynone: bool
+            True = do not copy EXIF data (False by default)
+
+        Returns
+        ----------
+        bytes
+            Huffman-optimized jpeg image.
+        """
+        handle = self.__init(TJINIT_TRANSFORM)
+        try:
+            jpeg_array = np.frombuffer(jpeg_buf, dtype=np.uint8)
+            src_addr = self.__getaddr(jpeg_array)
+            status = self.__decompress_header(handle, src_addr, jpeg_array.size)
+            if status != 0:
+                self.__report_error(handle)
+            # Without TJXOPT_CROP the cropping region is ignored and the whole
+            # image is transformed, so the (zeroed) region needs no setup.
+            transforms = (TransformStruct * 1)()
+            transforms[0].op = TJXOP_NONE
+            transforms[0].options = TJXOPT_OPTIMIZE | (copynone and TJXOPT_COPYNONE)
+            return self.__do_transform(handle, src_addr, jpeg_array.size, 1, transforms)[0]
 
         finally:
             self.__destroy(handle)


### PR DESCRIPTION
Add method to do Huffman optimization to jpeg encoded frame, which can offer reduced file size without any loss of quality.