### PR TITLE
Add method for lossless optimization of Huffman tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,13 @@ with open('input.jpg', 'rb') as f:
     cropped_data = jpeg.crop(f.read(), 8, 8, 320, 240)
 with open('cropped_output.jpg', 'wb') as f:
     f.write(cropped_data)
+
+# Lossless Huffman table optimization (re-encodes with optimal tables,
+# identical pixels; typically smaller unless already optimized)
+with open('input.jpg', 'rb') as f:
+    optimized_data = jpeg.optimize(f.read())
+with open('optimized_output.jpg', 'wb') as f:
+    f.write(optimized_data)
 ```
 
 ### In-Place Operations

--- a/TESTING.md
+++ b/TESTING.md
@@ -26,6 +26,7 @@ The test suite covers all core functions of PyTurboJPEG plus regression tests fo
 - **scale_with_quality()** - Tests scaling and quality adjustment
 - **crop()** - Tests lossless crop operations
 - **crop_multiple()** - Tests multiple crop operations with background handling
+- **optimize()** - Tests lossless Huffman table optimization
 - **buffer_size()** - Tests buffer size calculation
 - **scaling_factors** - Tests the scaling factors property
 
@@ -109,6 +110,7 @@ Each test class focuses on a specific function or feature:
 - `TestScaleWithQuality` - Tests scaling with quality adjustment
 - `TestCrop` - Tests lossless crop operations
 - `TestCropMultiple` - Tests multiple crop operations
+- `TestOptimize` - Tests lossless Huffman table optimization
 - `TestBufferSize` - Tests buffer size calculation
 - `TestErrorHandling` - Tests error conditions
 - `TestIntegration` - Tests complete workflows

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import io
 from setuptools import setup, find_packages
 setup(
     name='PyTurboJPEG',
-    version='2.3.0',
+    version='2.4.0',
     description='A Python wrapper of libjpeg-turbo for decoding and encoding JPEG image.',
     author='Lilo Huang',
     author_email='kuso.cc@gmail.com',

--- a/tests/test_turbojpeg.py
+++ b/tests/test_turbojpeg.py
@@ -513,6 +513,17 @@ class TestCropMultiple:
         assert subsample == TJSAMP_GRAY
 
 
+class TestOptimize:
+    """Test optimize function."""
+
+    def test_optimize_is_lossless(self, jpeg_instance, encoded_sample_jpeg):
+        """Test optimization returns a valid JPEG with unchanged pixels."""
+        optimized = jpeg_instance.optimize(encoded_sample_jpeg)
+        original_pixels = jpeg_instance.decode(encoded_sample_jpeg)
+        optimized_pixels = jpeg_instance.decode(optimized)
+        assert np.array_equal(original_pixels, optimized_pixels)
+
+
 class TestBufferSize:
     """Test buffer_size function."""
     

--- a/turbojpeg.py
+++ b/turbojpeg.py
@@ -125,6 +125,7 @@ TJXOPT_GRAY = 8
 TJXOPT_NOOUTPUT = 16
 TJXOPT_PROGRESSIVE = 32
 TJXOPT_COPYNONE = 64
+TJXOPT_OPTIMIZE = 256  # Huffman table optimization
 
 # pixel size
 # see details in https://github.com/libjpeg-turbo/libjpeg-turbo/blob/main/src/turbojpeg.h
@@ -1347,6 +1348,43 @@ class TurboJPEG(object):
             results = self.__do_transform(handle, src_addr, jpeg_array.size, number_of_operations, crop_transforms)
 
             return results
+
+        finally:
+            self.__destroy(handle)
+
+    def optimize(self, jpeg_buf, copynone=False):
+        """Losslessly optimize the Huffman tables of a jpeg image.
+
+        Re-encodes the entropy-coded data with optimal Huffman tables
+        (equivalent to ``jpegtran -optimize``) without any loss in image
+        quality. Typically reduces file size, unless the input is already
+        optimized.
+
+        Parameters
+        ----------
+        jpeg_buf: bytes
+            Input jpeg image.
+        copynone: bool
+            True = do not copy EXIF data (False by default)
+
+        Returns
+        ----------
+        bytes
+            Huffman-optimized jpeg image.
+        """
+        handle = self.__init(TJINIT_TRANSFORM)
+        try:
+            jpeg_array = np.frombuffer(jpeg_buf, dtype=np.uint8)
+            src_addr = self.__getaddr(jpeg_array)
+            status = self.__decompress_header(handle, src_addr, jpeg_array.size)
+            if status != 0:
+                self.__report_error(handle)
+            # Without TJXOPT_CROP the cropping region is ignored and the whole
+            # image is transformed, so the (zeroed) region needs no setup.
+            transforms = (TransformStruct * 1)()
+            transforms[0].op = TJXOP_NONE
+            transforms[0].options = TJXOPT_OPTIMIZE | (copynone and TJXOPT_COPYNONE)
+            return self.__do_transform(handle, src_addr, jpeg_array.size, 1, transforms)[0]
 
         finally:
             self.__destroy(handle)

--- a/turbojpeg.py
+++ b/turbojpeg.py
@@ -23,7 +23,7 @@
 # SOFTWARE.
 
 __author__ = 'Lilo Huang <kuso.cc@gmail.com>'
-__version__ = '2.3.0'
+__version__ = '2.4.0'
 
 from ctypes import *
 from ctypes.util import find_library


### PR DESCRIPTION
This pull request introduces a new lossless JPEG optimization feature to the library, allowing users to optimize Huffman tables in JPEG images for smaller file sizes without changing pixel data. The update includes the new `optimize` method, corresponding tests, documentation updates, and a version bump to 2.4.0.

**New Feature: Lossless Huffman Table Optimization**
- Added the `optimize` method to the `TurboJPEG` class, enabling lossless optimization of JPEG Huffman tables (similar to `jpegtran -optimize`). This reduces file size while preserving image data, with an option to exclude EXIF data. [[1]](diffhunk://#diff-b6fab2bbc07480db7b43c5de85f74bba4417bd6b7016366653568494d3ede5c7R1355-R1391) [[2]](diffhunk://#diff-b6fab2bbc07480db7b43c5de85f74bba4417bd6b7016366653568494d3ede5c7R128)

**Documentation and Example Updates**
- Updated `README.md` with a usage example for the new `optimize` method.
- Expanded `TESTING.md` to document the new `optimize` test and its coverage in the test suite. [[1]](diffhunk://#diff-4da5f2fd7bc2f11672282410e99aad91d422f9f4fb6c723abc7ef29ee5cb6906R29) [[2]](diffhunk://#diff-4da5f2fd7bc2f11672282410e99aad91d422f9f4fb6c723abc7ef29ee5cb6906R113)

**Testing**
- Added a new `TestOptimize` class in `tests/test_turbojpeg.py` to verify that the optimization is lossless and produces valid JPEGs with unchanged pixels.

**Versioning**
- Bumped the version to `2.4.0` in both `setup.py` and `turbojpeg.py` to reflect the new feature addition. [[1]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L5-R5) [[2]](diffhunk://#diff-b6fab2bbc07480db7b43c5de85f74bba4417bd6b7016366653568494d3ede5c7L26-R26)